### PR TITLE
Wagtail 4.0 deprecation warnings

### DIFF
--- a/wagtail_favicon/models.py
+++ b/wagtail_favicon/models.py
@@ -4,7 +4,6 @@ from django.utils.functional import cached_property
 from wagtail.admin.edit_handlers import MultiFieldPanel, FieldPanel
 from wagtail.contrib.settings.models import BaseSetting, register_setting
 from wagtail.images import get_image_model_string
-from wagtail.images.edit_handlers import ImageChooserPanel
 
 from .validators import validate_hex
 
@@ -82,7 +81,7 @@ class FaviconSettings(BaseSetting, FaviconRenditions):
             [
                 FieldPanel('app_name'),
                 FieldPanel('app_theme_color'),
-                ImageChooserPanel('base_favicon_image'),
+                FieldPanel('base_favicon_image'),
             ],
             heading="Favicon Settings",
             classname="collapsible"
@@ -91,5 +90,3 @@ class FaviconSettings(BaseSetting, FaviconRenditions):
 
     class Meta:
         verbose_name = 'Favicon'
-
-


### PR DESCRIPTION
In [Wagtail 3.0](https://docs.wagtail.org/en/stable/reference/pages/panels.html#module-wagtail.images.edit_handlers), `ImageChooserPanel` was deprecated; plain `FieldPanel` is smart enough to handle regular and image fields now. In Wagtail 4.0, use of `ImageChooserPanel` produces `RemovedInWagtail50Warning`. This PR removes the use of `ImageChooserPanel`.