### PR TITLE
Add support for using the image serve view if available

### DIFF
--- a/wagtail_favicon/models.py
+++ b/wagtail_favicon/models.py
@@ -7,6 +7,7 @@ from wagtail.images import get_image_model_string
 from wagtail.images.edit_handlers import ImageChooserPanel
 
 from .validators import validate_hex
+from .utils import get_rendition_url
 
 
 class FaviconRenditions:
@@ -29,11 +30,6 @@ class FaviconRenditions:
         '57x57',
     ]
 
-    def get_rendition(self, size):
-        image = self.base_favicon_image
-        rendition = image.get_rendition(f'fill-{size}')
-        return rendition.url
-
     def make_renditions(self, sizes):
         if self.base_favicon_image is None:
             return []
@@ -41,7 +37,7 @@ class FaviconRenditions:
         return [
             {
                 'size': size,
-                'url': self.get_rendition(size)
+                'url': get_rendition_url(self.base_base_favicon_image, f'fill-{size}')
             } for size in sizes
         ]
 
@@ -91,5 +87,3 @@ class FaviconSettings(BaseSetting, FaviconRenditions):
 
     class Meta:
         verbose_name = 'Favicon'
-
-

--- a/wagtail_favicon/models.py
+++ b/wagtail_favicon/models.py
@@ -37,7 +37,7 @@ class FaviconRenditions:
         return [
             {
                 'size': size,
-                'url': get_rendition_url(self.base_base_favicon_image, f'fill-{size}')
+                'url': get_rendition_url(self.base_favicon_image, f'fill-{size}')
             } for size in sizes
         ]
 

--- a/wagtail_favicon/templates/tags/favicon_meta.html
+++ b/wagtail_favicon/templates/tags/favicon_meta.html
@@ -8,7 +8,7 @@
     {% endfor %}
 
     {% if ms_image %}
-        <meta name="msapplication-TileImage" content="{{ ms_image.url }}" />
+        <meta name="msapplication-TileImage" content="{{ ms_image }}" />
     {% endif %}
 {% endif %}
 
@@ -20,4 +20,3 @@
 {% if icon_image %}
     <link rel="manifest" href="/manifest.json" />
 {% endif %}
-

--- a/wagtail_favicon/templatetags/favicon_tags.py
+++ b/wagtail_favicon/templatetags/favicon_tags.py
@@ -2,7 +2,7 @@ from django import template
 from wagtail.core.models import Site
 
 from wagtail_favicon.models import FaviconSettings
-from .utils import get_rendition_url
+from wagtail_favicon.utils import get_rendition_url
 
 register = template.Library()
 

--- a/wagtail_favicon/templatetags/favicon_tags.py
+++ b/wagtail_favicon/templatetags/favicon_tags.py
@@ -2,6 +2,7 @@ from django import template
 from wagtail.core.models import Site
 
 from wagtail_favicon.models import FaviconSettings
+from .utils import get_rendition_url
 
 register = template.Library()
 
@@ -11,7 +12,7 @@ def favicon_meta(context):
     site = Site.find_for_request(context.get('request'))
     favicon_settings = FaviconSettings.for_site(site)
     icon_image = favicon_settings.base_favicon_image
-    ms_image = icon_image.get_rendition('fill-144x144') if icon_image else None
+    ms_image = get_rendition_url(icon_image, 'fill-144x144') if icon_image else None
 
     return {
         'icon_image': icon_image,

--- a/wagtail_favicon/utils.py
+++ b/wagtail_favicon/utils.py
@@ -1,0 +1,16 @@
+from wagtail.images.views.serve import generate_image_url
+from django.urls import NoReverseMatch
+
+
+def get_rendition_url(image, filter_spec):
+    """
+    Efficiently get the URL for a rendition.
+
+    If enabled, will attempt to use the image serve view before retrieving the rendition URL directly.
+    https://docs.wagtail.org/en/stable/advanced_topics/images/image_serve_view.html
+    """
+    try:
+        return generate_image_url(image, filter_spec)
+    except NoReverseMatch:
+        # Serve view isn't available, fall back to direct URL
+        return image.get_rendition(filter_spec).url

--- a/wagtail_favicon/views.py
+++ b/wagtail_favicon/views.py
@@ -3,6 +3,7 @@ from django.http import JsonResponse, Http404
 from wagtail.core.models import Site
 
 from .models import FaviconSettings
+from .utils import get_rendition_url
 
 
 def browser_config(request):
@@ -18,9 +19,9 @@ def browser_config(request):
         {
             'request': request,
             'app_theme_color': settings.app_theme_color,
-            'icon_70': image.get_rendition('fill-70x70').url,
-            'icon_150': image.get_rendition('fill-150x150').url,
-            'icon_310': image.get_rendition('fill-310x310').url,
+            'icon_70': get_rendition_url(image, 'fill-70x70'),
+            'icon_150': get_rendition_url(image, 'fill-150x150'),
+            'icon_310': get_rendition_url(image, 'fill-310x310'),
         },
         content_type='application/xml'
     )
@@ -36,32 +37,32 @@ def icon_manifest(request):
     content = {
         'icons': [
             {
-                "src": image.get_rendition('fill-36x36').url,
+                "src": get_rendition_url(image, 'fill-36x36'),
                 "sizes": "36x36",
                 "type": "image/png",
                 "density": "0.75"
             }, {
-                "src": image.get_rendition('fill-48x48').url,
+                "src": get_rendition_url(image, 'fill-48x48'),
                 "sizes": "48x48",
                 "type": "image/png",
                 "density": "1.0"
             }, {
-                "src": image.get_rendition('fill-72x72').url,
+                "src": get_rendition_url(image, 'fill-72x72'),
                 "sizes": "72x72",
                 "type": "image/png",
                 "density": "1.5"
             }, {
-                "src": image.get_rendition('fill-96x96').url,
+                "src": get_rendition_url(image, 'fill-96x96'),
                 "sizes": "96x96",
                 "type": "image/png",
                 "density": "2.0"
             }, {
-                "src": image.get_rendition('fill-144x144').url,
+                "src": get_rendition_url(image, 'fill-144x144'),
                 "sizes": "144x144",
                 "type": "image/png",
                 "density": "3.0"
             }, {
-                "src": image.get_rendition('fill-192x192').url,
+                "src": get_rendition_url('fill-192x192'),
                 "sizes": "192x192",
                 "type": "image/png",
                 "density": "4.0"
@@ -76,4 +77,3 @@ def icon_manifest(request):
         content['theme_color'] = settings.app_theme_color
 
     return JsonResponse(content)
-

--- a/wagtail_favicon/views.py
+++ b/wagtail_favicon/views.py
@@ -62,7 +62,7 @@ def icon_manifest(request):
                 "type": "image/png",
                 "density": "3.0"
             }, {
-                "src": get_rendition_url('fill-192x192'),
+                "src": get_rendition_url(image, 'fill-192x192'),
                 "sizes": "192x192",
                 "type": "image/png",
                 "density": "4.0"


### PR DESCRIPTION
This improves performance by removing the need to query every rendition upfront if only a few are going to be used. It also means renditions are created as images are used, rather than all at once. This reduces database queries (and potentially cache hits) for all pages.